### PR TITLE
Check whether show exists in archive before downloading

### DIFF
--- a/src/rooster/downloader.py
+++ b/src/rooster/downloader.py
@@ -55,13 +55,16 @@ def get_archive_log_filename():
     return archive_log_location
 
 
-def exists_in_archive(id_numerical):
+def exists_in_archive(episode_data):
+    id_episode = str(episode_data["id_numerical"])
+    if episode_data["season_number"] == "99":
+        id_episode += "-bonus"  # Handle bonus ids
     archive = get_archive_log_filename()
     if os.path.isfile(archive):
         with open(archive, "r") as f:
             for line in f:
-                id_archive = int(line.split(" ")[1])
-                if id_archive == id_numerical:
+                id_archive = line.split(" ")[1].rstrip()
+                if id_archive == id_episode:
                     return True
     return False
 
@@ -490,7 +493,7 @@ def show_stuff(username, password, vod_url, concurrent_fragments, show_mode):
         exit()
     api_url = get_rt_api_url(url=vod_url)
     episode_data = get_episode_data_from_rt_api(api_url)
-    if exists_in_archive(episode_data["id_numerical"]):
+    if exists_in_archive(episode_data):
         print(f'{episode_data["id_numerical"]}: {episode_data["title"]} already recorded in archive')
     else:
         if episode_data is False:

--- a/src/rooster/downloader.py
+++ b/src/rooster/downloader.py
@@ -55,6 +55,17 @@ def get_archive_log_filename():
     return archive_log_location
 
 
+def exists_in_archive(id_numerical):
+    archive = get_archive_log_filename()
+    if os.path.isfile(archive):
+        with open(archive, "r") as f:
+            for line in f:
+                id_archive = int(line.split(" ")[1])
+                if id_archive == id_numerical:
+                    return True
+    return False
+
+
 def extract_data_from_ytdl_dict(info_dict):
     episode_id = info_dict["id"]
     episode_title = info_dict["title"]
@@ -479,8 +490,11 @@ def show_stuff(username, password, vod_url, concurrent_fragments, show_mode):
         exit()
     api_url = get_rt_api_url(url=vod_url)
     episode_data = get_episode_data_from_rt_api(api_url)
-    if episode_data is False:
-        episode_data = get_episode_data_from_api(vod_url)
-    downloader(
-        username, password, vod_url, episode_data, concurrent_fragments, show_mode
-    )
+    if exists_in_archive(episode_data["id_numerical"]):
+        print(f'{episode_data["id_numerical"]}: {episode_data["title"]} already recorded in archive')
+    else:
+        if episode_data is False:
+            episode_data = get_episode_data_from_api(vod_url)
+        downloader(
+            username, password, vod_url, episode_data, concurrent_fragments, show_mode
+        )


### PR DESCRIPTION
Checks whether a show's numerical ID exists in archive.log before sending to downloader. Avoids relying upon yt_dlp.download(), which is slow to start, for identifying existing content. Will also avoid unnecessary calls to yt_dlp.extract_info() and re-downloading the thumbnail. Internally, it appears that yt-dlp also relies upon the log for identifying duplicates and does not directly check whether the file exists.

For reference, without these modifications, it takes ~23 seconds to process the nine links in `a_simple_walk_.txt`. With these changes, it takes only ~3 seconds.